### PR TITLE
fix: global wathlist response

### DIFF
--- a/src/Response/GlobalWatchlist.php
+++ b/src/Response/GlobalWatchlist.php
@@ -24,7 +24,7 @@ class GlobalWatchlist extends ResponseObject
     public function setReturnedDataAttribute($value)
     {
         $this->returnedData = [
-            'watchListResults' => (new WatchlistResultsCollection($value['watchlistResults']))->mapInto(WatchlistResult::class)
+            'watchListResults' => (new WatchlistResultsCollection($value['watchlistResults'] ?? []))->mapInto(WatchlistResult::class)
         ];
     }
 }


### PR DESCRIPTION
Added empty array as response if `watchlistResults` is missing in global watchlist results.